### PR TITLE
Refresh nseList before request vl3-endpoints

### DIFF
--- a/main.go
+++ b/main.go
@@ -357,6 +357,18 @@ func main() {
 
 	startListenPrefixes(ctx, config, tlsClientConfig, subscribedChannels)
 
+	// Update the nseList to make sure we have all registered vl3-endpoints
+	nseStream, err = nseRegistryClient.Find(ctx, &registryapi.NetworkServiceEndpointQuery{
+		NetworkServiceEndpoint: &registryapi.NetworkServiceEndpoint{
+			NetworkServiceNames: config.ServiceNames,
+		},
+	})
+
+	if err != nil {
+		log.FromContext(ctx).Fatalf("error getting nses: %+v", err)
+	}
+	nseList = registryapi.ReadNetworkServiceEndpointList(nseStream)
+
 	for i, nse := range nseList {
 		index := i + 1
 		if nse.Name == config.Name {


### PR DESCRIPTION
### Motivation

If we don't refresh nseList, we may miss a few registered vl3-nses.

Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>