### PR TITLE
Fix getDNSServerIP function

### DIFF
--- a/main.go
+++ b/main.go
@@ -213,8 +213,12 @@ func main() {
 	logrus.SetFormatter(&nested.Formatter{})
 
 	var dnsServerIP = new(atomic.Value)
-	dnsServerIP.Store(net.IP(nil))
-	config.getDNSServerIP = func() net.IP { return dnsServerIP.Load().(net.IP) }
+	config.getDNSServerIP = func() net.IP {
+		if ip := dnsServerIP.Load(); ip != nil {
+			return ip.(net.IP)
+		}
+		return nil
+	}
 
 	// ********************************************************************************
 	// Configure Open Telemetry


### PR DESCRIPTION
We don't need to use `net.IP(nil)`, because `net.IP(nil).String()` is `"<nil>"`

Issue: https://github.com/networkservicemesh/deployments-k8s/issues/6774

Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>