### PR TITLE
[qfix] Don't wait for vpp error event after termination signal

### DIFF
--- a/main.go
+++ b/main.go
@@ -468,7 +468,6 @@ func main() {
 	// wait for server to exit
 	<-signalCtx.Done()
 	closeSubscribedChannels()
-	<-vppErrCh
 }
 
 func createVl3Client(ctx context.Context, config *Config, vppConn vpphelper.Connection, tlsClientConfig *tls.Config, source x509svid.Source,


### PR DESCRIPTION
### Description

We don't need wait for vpp error event if we got a termination signal.
Because vl3-nse is a _**client**_ to other vl3 endpoints and we need to call `Close` correctly before the end. 

Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>