### PR TITLE
Use the same name for the client and server

### DIFF
--- a/main.go
+++ b/main.go
@@ -303,7 +303,7 @@ func main() {
 	nsmClient := retry.NewClient(
 		client.NewClient(ctx,
 			client.WithClientURL(&config.ConnectTo),
-			client.WithName(config.Name+"-kernel"),
+			client.WithName(config.Name),
 			client.WithAuthorizeClient(authorize.NewClient()),
 			client.WithAdditionalFunctionality(
 				append(


### PR DESCRIPTION
Issue: https://github.com/networkservicemesh/integration-k8s-kind/issues/750

Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>