### PR TITLE
Add interface names into NSM metrics

### DIFF
--- a/main.go
+++ b/main.go
@@ -39,6 +39,7 @@ import (
 
 	"github.com/networkservicemesh/sdk-vpp/pkg/networkservice/loopback"
 	"github.com/networkservicemesh/sdk-vpp/pkg/networkservice/mechanisms/memif"
+	"github.com/networkservicemesh/sdk-vpp/pkg/networkservice/stats"
 	"github.com/networkservicemesh/sdk-vpp/pkg/networkservice/up"
 	"github.com/networkservicemesh/sdk-vpp/pkg/networkservice/vrf"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/client"
@@ -554,6 +555,7 @@ func createVl3Endpoint(ctx context.Context, cancel context.CancelFunc, config *C
 			unnumbered.NewServer(vppConn, loopback.Load),
 			vrf.NewServer(vppConn, vrfOpts...),
 			loopback.NewServer(vppConn, loopOpts...),
+			stats.NewServer(ctx, vppConn, stats.InterfaceOnly(true)),
 			mechanisms.NewServer(map[string]networkservice.NetworkServiceServer{
 				memif.MECHANISM: chain.NewNetworkServiceServer(
 					sendfd.NewServer(),


### PR DESCRIPTION
Task: https://github.com/networkservicemesh/sdk-vpp/issues/768

Add interface details for NSE:
![metrixNew drawio (1)](https://github.com/networkservicemesh/cmd-nsc/assets/10182393/eb496fec-1833-4c26-adf9-33eceaed5b2f)

Depends on: https://github.com/networkservicemesh/sdk-vpp/pull/771